### PR TITLE
dyn Trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ pub fn hackfn(args: TokenStream, input: TokenStream) -> TokenStream {
     let ret_ty = ret_ty.map(|ret| quote!(-> #ret));
 
     let target = quote! {
-        ::std::ops::Fn(#(#arg_types),*) #ret_ty
+        dyn ::std::ops::Fn(#(#arg_types),*) #ret_ty
     };
 
     let expanded = quote! {


### PR DESCRIPTION
The expanded code triggers warnings without this:

```console
warning: trait objects without an explicit `dyn` are deprecated
  --> tests/readme.rs:33:19
   |
33 |     type Target = ::std::ops::Fn(T);
   |                   ^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn (::std::ops::Fn(T))`
   |
   = note: `#[warn(bare_trait_objects)]` on by default
   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>

warning: trait objects without an explicit `dyn` are deprecated
  --> tests/readme.rs:44:50
   |
44 |         unsafe { ::std::mem::transmute(__ret as &::std::ops::Fn(T)) }
   |                                                  ^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn (::std::ops::Fn(T))`
   |
   = warning: this is accepted in the current edition (Rust 2018) but is a hard error in Rust 2021!
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/warnings-promoted-to-error.html>
```