### PR TITLE
Work around ICE in rust 1.57+

### DIFF
--- a/tests/readme.rs
+++ b/tests/readme.rs
@@ -42,7 +42,7 @@ mod second {
 
     #[test]
     fn main() {
-        let accumulate = AccumulatePairs::default();
+        let accumulate = AccumulatePairs::<i32>::default();
         accumulate(30, 1);
         accumulate(20, 2);
         accumulate(10, 3);


### PR DESCRIPTION
Minimized and filed as https://github.com/rust-lang/rust/issues/91807.

```console
thread 'rustc' panicked at 'forcing query with already existing `DepNode`
- query-key: Binder(std::ops::FnOnce<({integer}, {integer})>, [])
- dep-node: own_existential_vtable_entries(e50a277812671f6b-aa29609e12f65147)', /rustc/0b42deaccc2cbe17a68067aa5fdb76104369e1fd/compiler/rustc_query_system/src/dep_graph/graph.rs:236:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

error: internal compiler error: unexpected panic

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.59.0-nightly (0b42deacc 2021-12-09) running on x86_64-unknown-linux-gnu

note: compiler flags: -C embed-bitcode=no -C debuginfo=2 -C incremental

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
#0 [own_existential_vtable_entries] finding all existential vtable entries for trait core::ops::function::FnOnce
#1 [evaluate_obligation] evaluating trait selection obligation `(dyn core::ops::function::Fn(^2_0, ^2_0) + 'static): core::ops::function::Fn<(^1_1, ^1_2)>`
end of query stack
```